### PR TITLE
Update pinned-requirements.txt

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -209,4 +209,4 @@ zipp==3.4.1; python_version < "3.7" and python_version >= "3.6"
 zipstream-new==1.1.8
 
 # anvil specific
-fs.anvilfs==0.2.0
+fs.anvilfs==0.2.1


### PR DESCRIPTION
changes in fs.anvilfs 0.2.1:
- workspace bucket files: now properly lists subdirectory files, and subdirectories are writable
- readme: include `writable` parameter info